### PR TITLE
Add elasticsearch-dsl requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas==1.3.3
 pytest==6.2.5
 whitenoise==5.3.0
 jinja-partials==0.1.0
+elasticsearch-dsl==7.4.0


### PR DESCRIPTION
The requirement for `elasticsearch-dsl` was missing in requirements.txt.