### PR TITLE
Fix id not found

### DIFF
--- a/app/domain/services.py
+++ b/app/domain/services.py
@@ -26,7 +26,8 @@ class OrganizationService:
         return results, results_number, total_pages
 
     def find_one(self, organization_id: str) -> Optional[Organization]:
-        return Organization(**self.search_client.find_one_organization(organization_id)) or None
+        found = self.search_client.find_one_organization(organization_id)
+        return Organization(**found) if found else None
 
 
 class DatasetService:
@@ -52,7 +53,8 @@ class DatasetService:
         return results, results_number, total_pages
 
     def find_one(self, dataset_id: str) -> Optional[Dataset]:
-        return Dataset(**self.search_client.find_one_dataset(dataset_id)) or None
+        found = self.search_client.find_one_dataset(dataset_id)
+        return Dataset(**found) if found else None
 
 
 class ReuseService:
@@ -78,4 +80,5 @@ class ReuseService:
         return results, results_number, total_pages
 
     def find_one(self, reuse_id: str) -> Optional[Reuse]:
-        return Reuse(**self.search_client.find_one_reuse(reuse_id)) or None
+        found = self.search_client.find_one_reuse(reuse_id)
+        return Reuse(**found) if found else None

--- a/app/infrastructure/search_clients.py
+++ b/app/infrastructure/search_clients.py
@@ -182,18 +182,18 @@ class ElasticClient:
 
     def find_one_organization(self, organization_id: str) -> Optional[dict]:
         try:
-            return SearchableOrganization.get(id=organization_id).to_dict()
+            return SearchableOrganization.get(id=organization_id).to_dict(skip_empty=False)
         except NotFoundError:
             return None
 
     def find_one_dataset(self, dataset_id: str) -> Optional[dict]:
         try:
-            return SearchableDataset.get(id=dataset_id).to_dict()
+            return SearchableDataset.get(id=dataset_id).to_dict(skip_empty=False)
         except NotFoundError:
             return None
 
     def find_one_reuse(self, reuse_id: str) -> Optional[dict]:
         try:
-            return SearchableReuse.get(id=reuse_id).to_dict()
+            return SearchableReuse.get(id=reuse_id).to_dict(skip_empty=False)
         except NotFoundError:
             return None


### PR DESCRIPTION
Fix 2 issues:
- Return a proper 404 if dataset id not found instead of a 500. Ex on : https://rechercher.etalab.studio/api/1/datasets/00000000000000/
- Return the object if found even if some values are missing instead of a 500 (for example, no `organization_id`, because the owner is a user) https://rechercher.etalab.studio/api/1/reuses/5e0cf0a28b4c41122cc4ca58/

For this second issue, we should be able to use the owner info instead of the organization info if relevant (nb of followers, id, etc). It is specially useful for reuses, because a lot of quality reuses are owned by a user.