### PR TITLE
Use correct name field for organization search

### DIFF
--- a/app/infrastructure/search_clients.py
+++ b/app/infrastructure/search_clients.py
@@ -116,7 +116,7 @@ class ElasticClient:
         s = SearchableOrganization.search().query('bool', should=[
                 query.Q(
                     'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['title^15','description^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['name^15','description^8'])]),
                         functions=[
                             query.SF("field_value_factor", field="orga_sp", factor=8, modifier='sqrt', missing=1),
                             query.SF("field_value_factor", field="orga_followers", factor=4, modifier='sqrt', missing=1),


### PR DESCRIPTION
Organizations have a name and not a title: https://github.com/etalab/recherche-data-gouv-fr/blob/a2419394258da9074ef661df630cb9908d15d21d/app/domain/entities.py#L11